### PR TITLE
Support NOMADS as source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 21.12b0
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3.8


### PR DESCRIPTION
This code allows either `ftpprd` or `nomads` to be used as a source.  The first iteration is against `ftpprd`